### PR TITLE
Feat: add pino logger

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "googleapis": "^144.0.0",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.11.4",
+        "pino": "^9.5.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "yaml": "^2.6.0"
@@ -30,6 +31,7 @@
         "husky": "^9.1.6",
         "nodemon": "^3.1.4",
         "openapi-typescript": "^7.4.4",
+        "pino-pretty": "^13.0.0",
         "prettier": "^3.3.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2"
@@ -2439,6 +2441,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "license": "MIT",
@@ -2704,6 +2714,15 @@
       "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "license": "MIT",
@@ -2809,6 +2828,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "license": "MIT",
@@ -2890,11 +2918,31 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3269,6 +3317,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "license": "MIT",
@@ -3432,6 +3486,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-levenshtein": {
@@ -3660,6 +3723,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
@@ -3795,6 +3867,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -3905,6 +3985,70 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
+      "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.0.0.tgz",
+      "integrity": "sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -3966,6 +4110,11 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
+      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
@@ -3988,6 +4137,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "license": "BSD-3-Clause",
@@ -4000,6 +4159,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quickselect": {
       "version": "2.0.0",
@@ -4047,6 +4211,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4081,9 +4253,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -4196,11 +4382,27 @@
       "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
       "license": "MIT"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/splaytree": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.2.tgz",
       "integrity": "sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A==",
       "license": "MIT"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sqlstring": {
       "version": "2.3.3",
@@ -4214,6 +4416,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -4286,6 +4500,14 @@
       "license": "MIT",
       "dependencies": {
         "tinyqueue": "^2.0.0"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tinyqueue": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/app.ts",
     "serve": "node dist/index.js",
     "build": "rm -rf dist && npx tsc",
-    "dev:start": "nodemon --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/app.ts",
+    "dev:start": "nodemon --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/app.ts | npx pino-pretty",
     "dev": "docker compose -f ../docker-compose-dev.yml --env-file ../.env.dev up -d --build",
     "dev:stop": "docker compose -f ../docker-compose-dev.yml down",
     "prettier": "npx prettier --write .",
@@ -31,6 +31,7 @@
     "openapi-typescript": "^7.4.4",
     "prettier": "^3.3.3",
     "ts-node": "^10.9.2",
+    "pino-pretty": "^13.0.0",
     "typescript": "^5.7.2"
   },
   "dependencies": {
@@ -44,6 +45,7 @@
     "mysql2": "^3.11.4",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "yaml": "^2.6.0"
+    "yaml": "^2.6.0",
+    "pino": "^9.5.0"
   }
 }

--- a/backend/src/Controller/authController.ts
+++ b/backend/src/Controller/authController.ts
@@ -16,18 +16,15 @@ export const authController = {
   //   res.status(200).json(response);
   // },
   signUp: async (req: Request, res: Response): Promise<void> => {
-    console.log(req.body);
     const { provider, email, name } = req.body;
     if (!email || !name || !provider) {
       throw new InputEmptyError();
     }
-    console.log(provider);
 
     const response = await signUpHandler.handle(req.body);
     res.status(200).json(response);
   },
   signIn: async (req: Request, res: Response): Promise<void> => {
-    console.log(req.body);
     const { email, password } = req.body;
     if (!email || !password) {
       throw new InputEmptyError();

--- a/backend/src/Database/migrate/init_db.ts
+++ b/backend/src/Database/migrate/init_db.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
+import logger from '../../Logger/index.js';
 dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,7 +34,7 @@ const initDatabase = async () => {
       multipleStatements: true,
     });
 
-    console.log('成功連接到 MySQL 資料庫。');
+    logger.info('成功連接到 MySQL 資料庫。');
 
     // 讀取 schema.sql
     const schemaPath = path.join(__dirname, 'schema.sql');
@@ -42,11 +43,11 @@ const initDatabase = async () => {
     // 執行 SQL 語句
     await connection.query(schema);
 
-    console.log('資料庫初始化完成。');
+    logger.info('資料庫初始化完成。');
 
     await connection.end();
   } catch (error) {
-    console.error('資料庫初始化失敗：', error);
+    logger.error('資料庫初始化失敗：', error as string);
     process.exit(1);
   }
 };

--- a/backend/src/Infrastructure/Repository/userRepo.ts
+++ b/backend/src/Infrastructure/Repository/userRepo.ts
@@ -2,6 +2,7 @@ import { User } from '../../Database/entity/user.js';
 import pool from '../../Database/database.js';
 import { RowDataPacket, ResultSetHeader, PoolConnection } from 'mysql2/promise';
 import { Signup } from '../../App/Features/User/SignUp/Types/api.js';
+import logger from '../../Logger/index.js';
 export const userRepo = {
   findByEmail: async (email: string): Promise<User | null> => {
     try {
@@ -14,7 +15,7 @@ export const userRepo = {
       }
       return null;
     } catch (error) {
-      console.error(`Error fetching user with email ${email}:`, error);
+      logger.error(error, `Error fetching user with email ${email}`);
       throw error;
     }
   },
@@ -29,7 +30,7 @@ export const userRepo = {
       }
       return null;
     } catch (error) {
-      console.error(`Error fetching user with id ${id}:`, error);
+      logger.error(error, `Error fetching user with id ${id}:`);
       throw error;
     }
   },
@@ -44,7 +45,7 @@ export const userRepo = {
       );
       return result.insertId;
     } catch (error) {
-      console.error(`Error creating user:`, error);
+      logger.error(error, `Error creating user:`);
       throw error;
     }
   },

--- a/backend/src/Infrastructure/Service/userService.ts
+++ b/backend/src/Infrastructure/Service/userService.ts
@@ -2,6 +2,7 @@ import { Signin } from '../../App/Features/User/SignIn/Types/api.js';
 import { Signup } from '../../App/Features/User/SignUp/Types/api.js';
 import pool from '../../Database/database.js';
 import { UserExistError, UserNotFoundError } from '../../Errors/errors.js';
+import logger from '../../Logger/index.js';
 import { Pmap } from '../../Types/common.js';
 import { userRepo } from '../Repository/userRepo.js';
 export const userService = {
@@ -19,7 +20,7 @@ export const userService = {
       return result;
     } catch (error) {
       await connection.rollback();
-      console.error('Error signing up:', error);
+      logger.error(error, 'Error signing up:');
       throw error;
     } finally {
       connection.release();
@@ -54,7 +55,7 @@ export const userService = {
       return result;
     } catch (error) {
       await connection.rollback();
-      console.error('Error signing up by OAuth:', error);
+      logger.error(error, 'Error signing up by OAuth:');
       throw error;
     } finally {
       connection.release();

--- a/backend/src/Logger/index.ts
+++ b/backend/src/Logger/index.ts
@@ -1,0 +1,14 @@
+import { multistream } from 'pino';
+// import pinoLoki from 'pino-loki';
+
+import { PinoLogger } from './pinoLogger.js';
+const streams = [{ stream: process.stdout }];
+
+const logger = new PinoLogger(
+  {
+    enabled: process.env.LOGGING_ENABLED === 'true',
+  },
+  multistream(streams),
+);
+
+export default logger;

--- a/backend/src/Logger/interface.ts
+++ b/backend/src/Logger/interface.ts
@@ -1,0 +1,8 @@
+export interface Logger {
+  trace(message: string, labels?: Record<string, any>): void;
+  debug(message: string, labels?: Record<string, any>): void;
+  info(message: string, labels?: Record<string, any>): void;
+  warn(message: string, labels?: Record<string, any>): void;
+  error(error: unknown, message?: string, labels?: Record<string, any>): void;
+  fatal(error: unknown, message?: string, labels?: Record<string, any>): void;
+}

--- a/backend/src/Logger/pinoLogger.ts
+++ b/backend/src/Logger/pinoLogger.ts
@@ -1,0 +1,46 @@
+import { pino } from 'pino';
+
+import { Logger } from './interface.js';
+
+export class PinoLogger implements Logger {
+  private readonly logger: pino.Logger;
+
+  constructor(
+    options: pino.LoggerOptions,
+    destinationStream?: pino.DestinationStream,
+  ) {
+    this.logger = pino(options, destinationStream);
+  }
+
+  trace(message: string, labels?: Record<string, any>): void {
+    this.logger.trace({ msg: message, ...labels });
+  }
+
+  debug(message: string, labels?: Record<string, any>): void {
+    this.logger.debug({ msg: message, ...labels });
+  }
+
+  info(message: string, labels?: Record<string, any>): void {
+    this.logger.info({ msg: message, ...labels });
+  }
+
+  warn(message: string, labels?: Record<string, any>): void {
+    this.logger.warn({ msg: message, ...labels });
+  }
+
+  error(error: unknown, message?: string, labels?: Record<string, any>): void {
+    if (error instanceof Error) {
+      this.logger.error({ err: error, ...labels }, message);
+    } else {
+      this.logger.error({ msg: error, ...labels });
+    }
+  }
+
+  fatal(error: unknown, message?: string, labels?: Record<string, any>): void {
+    if (error instanceof Error) {
+      this.logger.fatal({ err: error, ...labels }, message);
+    } else {
+      this.logger.fatal({ msg: error, ...labels });
+    }
+  }
+}

--- a/backend/src/Middlewares/auth.ts
+++ b/backend/src/Middlewares/auth.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 import { NextFunction, Request, Response } from 'express';
 import { NoTokenError } from '../Errors/errors.js';
 import { isTJwtTokenPayload } from '../utils/jwt.js';
+import logger from '../Logger/index.js';
 const { TokenExpiredError, NotBeforeError, JsonWebTokenError } = jwt;
 
 export const jwtAuthentication = async (
@@ -27,19 +28,19 @@ export const jwtAuthentication = async (
     next();
   } catch (err) {
     if (err instanceof NoTokenError) {
-      console.error('No token:', err);
+      logger.error(err, 'No token');
       res.status(401).json({ message: err.message });
     } else if (err instanceof TokenExpiredError) {
-      console.error('Token expired:', err);
+      logger.error(err, 'Token expired');
       res.status(403).json({ message: err.message });
     } else if (err instanceof NotBeforeError) {
-      console.error('Token not active:', err);
+      logger.error(err, 'Token not active');
       res.status(403).json({ message: err.message });
     } else if (err instanceof JsonWebTokenError) {
-      console.error('Invalid token:', err);
+      logger.error(err, 'Invalid token');
       res.status(403).json({ message: err.message });
     } else {
-      console.error('Unknown error:', err);
+      logger.error(err, 'Unknown error');
       res.status(403).json({ message: 'An unknown error occurred' });
     }
   }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { errorHandler } from './Middlewares/errorHandler.js';
 import weatherRouter from './Router/weatherRouter.js';
 import authRouter from './Router/authRouter.js';
+import logger from './Logger/index.js';
 
 const app = express();
 const port = process.env.BACKEND_PORT;
@@ -32,5 +33,5 @@ app.get('/api/health', (req: Request, res: Response) => {
 app.use(errorHandler);
 
 app.listen(port, () => {
-  console.log(`Server running at http://localhost:${port}`);
+  logger.info(`Server running at http://localhost:${port}`);
 });

--- a/backend/src/utils/tool.ts
+++ b/backend/src/utils/tool.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs';
 import crpyto from 'crypto';
+import logger from '../Logger/index.js';
 
 export const tool = {
   generateHashPassword: async (password: string): Promise<string> => {
@@ -20,7 +21,7 @@ export const tool = {
     try {
       return await bcrypt.compare(input, real);
     } catch (error) {
-      console.error('Error comparing passwords:', error);
+      logger.error('Error comparing passwords:', error as string);
       return false;
     }
   },


### PR DESCRIPTION
## main change
- 引入 pino logger 這個好用的東東，他被強調是一個高性能的日誌紀錄工具，而且可以很輕鬆跟 log 監控結合使用像 Grafana Loki，但我們畢竟是雲端原生課已經有 CloudWatch幫忙記錄了（？
- 之後棄用 console.log！改用 logger.info(), error()....已經封裝好模組化在 Logger 資料夾下了，也將註冊登入的部分都改用了 pino logger 作為範例
- log 出來會長這個樣子：`[14:16:57.709] INFO (219): Server running at http://localhost:3001`