### PR TITLE
fix/run weather compute at fist to prevent avgRainDegree null

### DIFF
--- a/cloud/lib/local/main.ts
+++ b/cloud/lib/local/main.ts
@@ -12,12 +12,17 @@ import { handler as computeWeatherHandler } from '../lambda-handler/compute-weat
 loadEnv();
 
 async function main() {
+  await init();
   cron.schedule('*/10 * * * *', async () => {
     console.log('Trigger weather pipeline');
     await startWeatherPipeline();
   });
 }
 
+// 初始先跑一次，避免 avgRainDegree 一開始是 null
+async function init() {
+  await startWeatherPipeline();
+}
 async function startWeatherPipeline() {
   const rep = await fetchWeatherHandler();
   await processWeatherHandler({ responsePayload: rep });


### PR DESCRIPTION
造成 avgRainDegree null 的一個原因：
- 初始時 avgRainDegree 在資料庫是 null，要等到每 10 分鐘（0, 10, 20...）才會執行計算天氣

所以：
- 現在讓 cloud 的 npm run local 會在一開始就算一次天氣，避免 avgRainDegree 是 null