### PR TITLE
Fix/fix weather api param lat and lng reversed

### DIFF
--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -318,7 +318,7 @@ components:
       schema:
         type: number
         format: double
-        example: 24.9914
+        example: 121.5667
     LatParam:
       name: lat
       in: query
@@ -327,7 +327,7 @@ components:
       schema:
         type: number
         format: double
-        example: 121.5667
+        example: 24.9914
     RadiusParam:
       name: radius
       in: query

--- a/backend/src/Infrastructure/Repository/PolygonRepo.ts
+++ b/backend/src/Infrastructure/Repository/PolygonRepo.ts
@@ -11,7 +11,7 @@ export const polygonRepo = {
     try {
       const [rows] = await pool.query<Polygon[]>(
         'SELECT * FROM Polygons WHERE ST_Distance_Sphere(POINT(centerLng, centerLat), POINT(?, ?)) <= ?',
-        [lat, lng, radius],
+        [lng, lat, radius],
       );
       return rows as Polygon[];
     } catch (error) {


### PR DESCRIPTION
修正 weather API 的 lat 和 lng 在code 裡面寫反了
因為之前給的測試URL也是 lat 和 lng 寫反，所以錯錯抵銷 😅 出來的結果是正常的

感謝威廷發現 bug 🙇 

舊的（lat 和 lng 反了）：
`http://localhost:3000/api/1.0/weather?lng=24.9914&lat=121.5667&radius=99999`

現在（正確的）：
`http://localhost:3000/api/1.0/weather?lat=24.9914&lng=121.5667&radius=99999`