### PR TITLE
Fix/staging map box not showing, add NEXT_PUBLIC env vars in build args

### DIFF
--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -16,6 +16,11 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      # NEXT_PUBLIC_variables need to be presented when build time
+      args:
+        NEXT_PUBLIC_MAPBOX_TOKEN: ${NEXT_PUBLIC_MAPBOX_TOKEN}
+        NEXT_PUBLIC_SOCKET_ORIGIN: ${NEXT_PUBLIC_SOCKET_ORIGIN}
+        NEXT_PUBLIC_SOCKET_URL: ${NEXT_PUBLIC_SOCKET_URL}
     container_name: pmap_frontend_container
     tty: true
     env_file:


### PR DESCRIPTION
Fix staging map box not showing


- NEXT_PUBLIC 的環境變數都要在 build image 時提供，會 build 進前端



![image](https://github.com/user-attachments/assets/43a3fc28-8465-4d9c-b303-41cdeb6783d8)
