### PR TITLE
Test/web frontend can recieved notification from websocket

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import React, { ReactNode } from "react";
-import ToastProvider from "./ToastProvider"; // 引入剛才建立的 Providers
 import { SessionProvider } from "next-auth/react";
 import { NextUIProvider } from "@nextui-org/react";
 import { ModalProvider } from "../contexts/ModalContext"; // Modal 狀態管理
 import { MapProvider } from "../contexts/MapContext"; // 地圖狀態管理
 import { UserProvider } from "../contexts/UserContext"; // 使用者狀態管理
 import { ThemeProvider } from "../contexts/ThemeContext"; // 主題狀態管理
+import { Socket } from "dgram";
+import { SocketProvider } from "./socketProvider";
+import ToastProvider from "./ToastProvider";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -17,7 +19,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <ModalProvider>
             <ThemeProvider>
               <MapProvider>
+                <SocketProvider>
                 <ToastProvider>{children}</ToastProvider>
+                </SocketProvider>
               </MapProvider>
             </ThemeProvider>
           </ModalProvider>

--- a/frontend/app/socketProvider.tsx
+++ b/frontend/app/socketProvider.tsx
@@ -4,6 +4,9 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { io, Socket } from "socket.io-client";
 import { useSession } from "next-auth/react";
 
+// TODO: this is jus tfor testing
+import { toast } from 'react-toastify';
+  
 declare module "next-auth" {
   interface Session {
     access_token?: string;
@@ -18,17 +21,28 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
 
   useEffect(() => {
-    if (status === "authenticated" && session?.access_token) {
-      console.log("Initializing Socket.IO with token:", session.access_token);
-
-      const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:3000", {
-        auth: { token: session.access_token },
-        path: "/api/socket",
-      });
+    console.log("Socket provider initialized");
+    console.log("Session status:", status);
+    
+    if (session?.access_token) {
+      console.log("Initializing Socket.IO with url:", process.env.NEXT_PUBLIC_SOCKET_URL);
+      
+      const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_URL);
 
       newSocket.on("connect", () => {
         console.log("Socket.IO connected:", newSocket.id);
+        const userId =  1; // TODO: Use real UserID
+        // 發送訊息到伺服器
+        newSocket.emit('message', JSON.stringify({ userId: userId }));
       });
+
+          // 監聽來自伺服器的訊息
+      newSocket.on('message', (data) => {
+        console.log('Socket.io 來自伺服器的訊息:', data);
+        // 收到訊息參考學長的格式
+        toast(data);
+      });
+
 
       setSocket(newSocket);
 


### PR DESCRIPTION
**這 PR 不用 merge**
只是測一下（[前一隻 PR](https://github.com/nccu-cloud-native-group6/pmap/pull/48#issuecomment-2563341239)）前端可以成功收到通知系統的訊息 & **怎麼連線的設定** @chuang091 
測到一半發現也要加 cors，已經改好在 feat/implement-sub 了


前置作業：
1. 檢查 notifcationServer 資料夾底下的 .env 們存在 -> 參考(https://github.com/nccu-cloud-native-group6/pmap/pull/48)
2. 檢查 root 的 .env.dev 有 `NOTIFY_SOCKET_PORT=3002`
2. 檢查 local `.env.developement` 的 NEXT_PUBLIC_SOCKET_URL
`NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 # Update!!`
3. 照常 backend  npm run dev
4.  code 使用 socket.io client 連入
```ts
const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_URL); 
```

ps. 具體要做的事情就跟學長提供的 testClient.js 一魔樣：
```js

export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
  // ...
  useEffect(() => {
    //...
    
    if (session?.access_token) {
      console.log("Initializing Socket.IO with url:", process.env.NEXT_PUBLIC_SOCKET_URL);
     // 這裡不用帶認證（目前沒做）
      const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_URL);

      newSocket.on("connect", () => {
        console.log("Socket.IO connected:", newSocket.id);
        const userId =  1; // TODO: Use real UserID
        // 發送 user id 
        newSocket.emit('message', JSON.stringify({ userId: userId }));
      });

      newSocket.on('message', (data) => {
        console.log('Socket.io 來自伺服器的訊息:', data);
        // TODO: 收到訊息參考學長的格式
        toast(data);
      });
    //....
```

https://github.com/user-attachments/assets/ebb45803-d874-4115-96d7-b0021ec066ea

（右邊一堆錯是跟因為這個 test branch 是亂長出來的，前後端有些通知以外 code 對不起來，不用理它）

