### PR TITLE
Feat/frontend notification toast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
             --build-arg NEXT_PUBLIC_MAPBOX_TOKEN=${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }} \
             --build-arg NEXT_PUBLIC_BACKEND_API_URL=${{ secrets.NEXT_PUBLIC_BACKEND_API_URL }} \
             --build-arg NEXT_PUBLIC_RECAPTCHA_SITE_KEY=${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY }} \
+            --build-arg NEXT_PUBLIC_SOCKET_URL=${{ secrets.NEXT_PUBLIC_SOCKET_URL }} \
             --build-arg NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }} \
             --cache-from ${{ env.CI_REGISTRY_IMAGE }}-frontend-${{ github.ref_name }}:latest \
             -t ${{ env.CI_REGISTRY_IMAGE }}-frontend-${{ github.ref_name }}:${{ github.run_id }} \

--- a/frontend/.env.development.example
+++ b/frontend/.env.development.example
@@ -26,3 +26,5 @@ NEXT_PUBLIC_BACKEND_API_URL=http://your_backend_api_url
 
 #Recaptcha
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY=your_recaptcha_site_key
+
+NEXT_PUBLIC_SOCKET_URL=http://localhost:3002

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -9,6 +9,7 @@ import { MapProvider } from "../contexts/MapContext"; // 地圖狀態管理
 import { UserProvider } from "../contexts/UserContext"; // 使用者狀態管理
 import { ThemeProvider } from "../contexts/ThemeContext"; // 主題狀態管理
 import { MapLayerProvider } from "../contexts/MapLayerContext"; // 地圖圖層狀態管理
+import { SocketProvider } from "./socketProvider";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -18,9 +19,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <NextUIProvider>
           <ModalProvider>
             <ThemeProvider>
-              <MapProvider>
-                <ToastProvider>{children}</ToastProvider>
-              </MapProvider>
+                <SocketProvider>
+                  <MapProvider>
+                    <ToastProvider>{children}</ToastProvider>
+                  </MapProvider>
+                </SocketProvider>
             </ThemeProvider>
           </ModalProvider>
         </NextUIProvider>

--- a/frontend/components/header/RainDegreeDisplay.tsx
+++ b/frontend/components/header/RainDegreeDisplay.tsx
@@ -5,7 +5,7 @@ interface RainDegreeDisplayProps {
   rainDegree: number;
 }
 
-const rainDescriptions = [
+export const rainDescriptions = [
   "大晴天 ☀️",
   "保濕噴霧雨 🌫️",
   "小雨 🌦️",

--- a/frontend/components/header/index.tsx
+++ b/frontend/components/header/index.tsx
@@ -33,7 +33,7 @@ const Header: React.FC<HeaderProps> = ({ mapRef, onTogglePanel }) => {
       <div className="hidden sm:block">
         <HeaderBookmark onTogglePanel={onTogglePanel} />
       </div>
-      <Notification />
+      <Notification mapRef={mapRef}/>
       <Location mapRef={mapRef} onWeatherIdFetch={setRainDegree} />
       <Login />
     </header>

--- a/frontend/components/map/addHexGrid.ts
+++ b/frontend/components/map/addHexGrid.ts
@@ -47,6 +47,9 @@ function getNeighborIds(
   return Array.from(neighbors);
 }
 
+export const polygonIdToLatLng: Map<number, Location> = new Map();
+
+
 export const addHexGrid = async (
   map: L.Map,
   isDark: boolean,
@@ -144,6 +147,12 @@ export const addHexGrid = async (
         color: getColor(hexValue, isDark),
         weight: 1,
         fillOpacity: 0.5,
+      });
+      
+      // Save the center of the polygon
+      polygonIdToLatLng.set(Number(id), {
+        lat: coords[0][0],
+        lng: coords[0][1],
       });
 
       polygon.bindPopup(`Hex ID: ${id}<br>Avg Rain Degree: ${hexValue}`);

--- a/frontend/components/notification/index.tsx
+++ b/frontend/components/notification/index.tsx
@@ -262,7 +262,7 @@ const formatSummaryMessage = (
 };
 
 const formatNewReportMessage = (data: NewReportNotification): string => {
-  return `${data.nickname} 出現了新的回報：${rainDescriptions[data.rainDegree]}(${data.rainDegree})`;
+  return `${data.nickname} 出現了新的回報：${rainDescriptions[data.rainDegree]} (${data.rainDegree})`;
 };
 
 /**

--- a/frontend/components/notification/index.tsx
+++ b/frontend/components/notification/index.tsx
@@ -133,12 +133,6 @@ export default function Notification({ mapRef }: NotificationProps) {
     return message;
   };
 
-  
-  // const onTestNotification = () => {
-  //   handleNotification(JSON.stringify(mockFixedTimeSummary));
-  //   handleNotification(JSON.stringify(mockNewReport));
-  // };
-
   useEffect(() => {
     if (socket?.connected) {
       console.log("[Notification] Socket connected");
@@ -176,8 +170,6 @@ export default function Notification({ mapRef }: NotificationProps) {
 
       <PopoverContent>
         <div style={{ padding: "1rem", width: "300px" }}>
-          {/* 測試用按鈕 */}
-          {/* <NotificationTestButton onClick={onTestNotification} /> */}
           <h4 style={{ marginBottom: "1rem" }}>Notifications</h4>
           <Divider />
           <div
@@ -289,37 +281,3 @@ function parseNotificationData(
   parsedData.type = NotificationType.WEATHER_SUMMARY;
   return parsedData as FixedTimeSummaryNotification;
 }
-
-// 測試用
-// Create mock data for both types of notifications
-// const mockFixedTimeSummary: FixedTimeSummaryNotification = {
-//   userId: "2",
-//   email: "pmap@gmail.com",
-//   subId: "22",
-//   nickname: "台北總公司",
-//   rainDegree: [{ id: 3, avgRainDegree: 4 }],
-// };
-
-// const mockNewReport: NewReportNotification = {
-//   userId: "2",
-//   email: "pmap@gmail.com",
-//   subId: "20",
-//   nickname: "台北總公司",
-//   reportId: "42",
-//   polygonId: 3,
-//   rainDegree: 3,
-// };
-
-// interface NotificationTestButtonProps {
-//   onClick: () => void;
-// }
-
-// export const NotificationTestButton: React.FC<NotificationTestButtonProps> = ({
-//   onClick,
-// }: NotificationTestButtonProps) => {
-//   return (
-//     <Button variant="bordered" onPress={onClick}>
-//       Notify
-//     </Button>
-//   );
-// };

--- a/notificationServer/socket/.env.dev.example
+++ b/notificationServer/socket/.env.dev.example
@@ -1,2 +1,2 @@
-MQ_URL=mqtt://pmap_mq_container:1883
+MQ_URL=mqtt://pmap-mq-container:1883
 CLIENT_URL=http://localhost:3001

--- a/notificationServer/socket/.env.example
+++ b/notificationServer/socket/.env.example
@@ -1,2 +1,2 @@
-MQ_URL=mqtt://pmap_mq_container:1883
+MQ_URL=mqtt://pmap-mq-container:1883
 CLIENT_URL=http://localhost:3001

--- a/notificationServer/socket/socket.js
+++ b/notificationServer/socket/socket.js
@@ -35,6 +35,8 @@ server.listen(PORT, () => {
 });
 
 mqttClient.on("message", (topic, message) => {
+    if(topic != "WEBSOCKET") return;
+    
     data = JSON.parse(message.toString());
     if (data.length > 0) {
         console.log(data);


### PR DESCRIPTION
先用鈴鐺 emoji

新回報：
![image](https://github.com/user-attachments/assets/6c04b941-d887-41eb-bc91-471d7d721948)

定時：
![image](https://github.com/user-attachments/assets/a007840e-0d81-4801-beb2-10fabb432bb1)

- 點下去正常回移動到 polygonId
- 收到通知會存到 notifioncations state 裡

